### PR TITLE
[GEN-920] feature/sftp support

### DIFF
--- a/kubessh/app.py
+++ b/kubessh/app.py
@@ -132,6 +132,7 @@ class KubeSSH(Application):
             self.log.info(f'Loaded host key from {self.host_key_path}')
 
     async def start(self):
+        KubeSFTPServer.namespace = self.default_namespace
         await asyncssh.listen(
             host='',
             port=self.port,

--- a/kubessh/sftp.py
+++ b/kubessh/sftp.py
@@ -21,8 +21,6 @@ import string
 
 logger = logging.getLogger('kubessh.sftp')
 
-# Default namespace where user pods are spawned
-POD_NAMESPACE = 'swlabpods-gc'
 
 
 def _make_pod_name(username):
@@ -48,6 +46,7 @@ class KubeSFTPFileHandle:
         self.is_append = is_append
         self.buffer = io.BytesIO()
         self.closed = False
+        self.pending_attrs = None  # Deferred attributes to apply on close
 
 
 class KubeSFTPServer(SFTPServer):
@@ -58,6 +57,9 @@ class KubeSFTPServer(SFTPServer):
     user's pod in the configured namespace.
     """
 
+    # Set by app.py before starting the server
+    namespace = None
+
     def __init__(self, chan):
         super().__init__(chan)
         
@@ -65,7 +67,7 @@ class KubeSFTPServer(SFTPServer):
         username = chan.get_extra_info('username')
         self._username = username
         self._pod_name = _make_pod_name(username)
-        self._namespace = POD_NAMESPACE
+        self._namespace = self.namespace
         
         logger.info(f'SFTP session started for user={username}, pod={self._pod_name}, namespace={self._namespace}')
 
@@ -193,6 +195,10 @@ class KubeSFTPServer(SFTPServer):
                 
                 logger.info(f'Written {len(data)} bytes to {file_obj.path} on pod {file_obj.pod_name}')
             
+            # Apply deferred attributes after file is written to pod
+            if file_obj.pending_attrs:
+                await self._apply_attrs(file_obj.path, file_obj.pending_attrs)
+            
             file_obj.closed = True
 
     async def read(self, file_obj, offset, size):
@@ -210,7 +216,7 @@ class KubeSFTPServer(SFTPServer):
         if isinstance(file_obj, KubeSFTPFileHandle):
             file_obj.buffer.seek(offset)
             file_obj.buffer.write(data)
-            return len(data)
+            return
         raise SFTPError(asyncssh.FX_FAILURE, 'Invalid file handle')
 
     # ─── File attribute methods ────────────────────────────────────────
@@ -272,7 +278,11 @@ class KubeSFTPServer(SFTPServer):
     async def fsetstat(self, file_obj, attrs):
         """Set file attributes on an open file handle (called by scp after upload)."""
         if isinstance(file_obj, KubeSFTPFileHandle):
-            await self._apply_attrs(file_obj.path, attrs)
+            if file_obj.is_write and not file_obj.closed:
+                # Defer attribute setting until close() when file is actually written to pod
+                file_obj.pending_attrs = attrs
+            else:
+                await self._apply_attrs(file_obj.path, attrs)
 
     async def _apply_attrs(self, path_str, attrs):
         """Apply file attributes to a path on the user's pod."""


### PR DESCRIPTION
[Bug Fix]
1. namespace 하드코딩 제거
- app.py의 default_namespace 설정값을 클래스 변수로 주입받도록 변경
2. write() 반환값 오류 수정
- asyncssh SFTPServer의 write()는 성공 시 None을 반환해야 하나 len(data)를 반환하고 있어 'Couldn't close file: Failure'  에러 발생
- return len(data) → return으로 수정
3. fsetstat() 타이밍 문제 수정
- SCP 업로드 시 close() 전에 fsetstat()이 호출되어 아직 Pod에 존재하지 않는 파일에 chmod/chown을 시도하는 문제
- pending_attrs로 속성 설정을 지연하여 close()에서 파일 쓰기 완료 후 적용되도록 수정